### PR TITLE
Fix `atplag`-only model specifications

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -146,7 +146,10 @@ deeptrafo <- function(
     tlag_formula <- paste0(grep("atplag", ftms, value = TRUE), collapse = "+")
     list_of_formulas$yterms <- as.formula(
       paste0(form2text(list_of_formulas$yterms), " + ", tlag_formula))
-    list_of_formulas$h2 <- drop.terms(tms, which(atps))
+    if (length(ftms) > length(which(atps)))
+      list_of_formulas$h2 <- drop.terms(tms, which(atps))
+    else
+      list_of_formulas$h2 <- ~1
 
   }
 

--- a/R/processor.R
+++ b/R/processor.R
@@ -138,22 +138,19 @@ basisprime_processor <- function(term, data, output_dim = NULL, param_nr, contro
 
 atm_lag_processor_factory <- function(rvar){
 
-  return(
-    atm_lag_processor <- function(term, data, output_dim = NULL, param_nr=4, controls=NULL)
-    {
+    atm_lag_processor <- function(term, data, output_dim = NULL, param_nr = 4,
+                                  controls = NULL) {
 
       name <- makelayername(term, param_nr)
-
-      layer <- eval_bsp_tf(order = controls$order_bsp, controls$supp(data[extractvar(rvar)]))
-
+      layer <- eval_bsp_tf(
+        order = controls$order_bsp, controls$supp(data[extractvar(rvar)])
+      )
       list(
         data_trafo = function() data[extractvar(term)],
         predict_trafo = function(newdata) newdata[extractvar(term)],
         input_dim = 1L,
         layer = layer
       )
-
     }
-  )
 
 }

--- a/tests/testthat/test_main.R
+++ b/tests/testthat/test_main.R
@@ -207,6 +207,17 @@ test_that("autoregressive transformation model", {
 
 })
 
+test_that("autoregressive transformation model specification", {
+
+  dat <- data.frame(y = rnorm(100), x = rnorm(100), z = rnorm(100))
+  dat$ylag <- lag(dat$y)
+  dat$ylag2 <- lag(dat$y, n = 2L)
+  dat <- na.omit(dat)
+  expect_length(coef(deeptrafo(y ~ atplag(ylag), data = dat), which = "auto"), 1)
+  expect_length(coef(deeptrafo(y ~ atplag(ylag) + atplag(ylag2), data = dat), which = "auto"), 2)
+
+})
+
 # Misc --------------------------------------------------------------------
 
 test_that("model with fixed weight", {

--- a/tests/testthat/test_main.R
+++ b/tests/testthat/test_main.R
@@ -191,8 +191,8 @@ test_that("survival model with NN component", {
 test_that("autoregressive transformation model", {
 
   dat <- data.frame(y = rnorm(100), x = rnorm(100), z = rnorm(100))
-  dat$ylag <- lag(dat$y)
-  dat$ylag2 <- lag(dat$y, n = 2L)
+  dat$ylag <- c(dat$y[-1], NA)
+  dat$ylag2 <- c(dat$y[-1:-2], NA, NA)
   dat <- na.omit(dat)
   fml <- y | s(x) ~ 0 + s(z) + atplag(ylag) + atplag(ylag2)
   m <- deeptrafo(fml, dat)


### PR DESCRIPTION
Prior to this update, model formulas including only `atplag`s in the shift term failed to build.